### PR TITLE
add docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rocker/shiny:latest
+
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev \
+    libgit2-dev \
+    git
+
+WORKDIR /srv/shiny-server/
+
+RUN git clone https://github.com/ExpectationsManaged/STRaitRazorOnline.git
+
+RUN R -e "install.packages(c('BiocManager', 'stringi', 'rhandsontable', 'tidyverse', 'shinydashboard', 'tcltk'), dependencies=TRUE)" \
+    && R -e "BiocManager::install(c('GenomeInfoDb', 'Biostrings', 'tidyselect'))"
+
+RUN chown -R shiny:shiny /srv/shiny-server
+
+CMD ["/init"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  myworkflow:
+    image:  lihaicheng7003/straitrazoronline:latest
+    container_name: straitrazoronline
+    ports:
+      - "3838:3838"


### PR DESCRIPTION
I noticed that the online version is based on Shiny, so I wrote a Dockerfile based on Shiny to make STRaitRazorOnline usable in Docker, increasing convenience. The build command is docker build -t straitrazoronline:latest ., and the command to start the container is docker compose up -d. After that, you can access and use it normally at http://127.0.0.1:3838/STRaitRazorOnline/. You can test it by pulling the image from docker pull lihaicheng7003/straitrazoronline:latest.

![image](https://github.com/user-attachments/assets/1da1ac24-31c0-4f61-87dd-6f7931ecf64a)
